### PR TITLE
Upgrade to Laravel 13.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+composer.lock
+.phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,16 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-core": "~1.0"
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-core": "~1.0.4"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {


### PR DESCRIPTION
## Summary
- Upgrades df-pubsub to Laravel 13.7 (PHP ^8.3, phpunit 11.5, testbench 11)
- **Composer-only change** — no source patches needed
- df-pubsub is an abstract base package; concrete pub/sub backends (Redis, AMQP, MQTT, etc.) live in sibling packages (`df-amqp`, `df-mqtt`)

## Changes
- `composer.json`:
  - `require`: pin `php ^8.3`, add `laravel/helpers ^1.8`, bump `dreamfactory/df-core` from `~1.0` to `~1.0.4`
  - new `require-dev`: `laravel/framework ^13.7`, `phpunit/phpunit ^11.5.3`, `orchestra/testbench ^11.0`, `mockery/mockery ^1.6`, `nunomaduro/collision ^8.6`
- `.gitignore` added (vendor, composer.lock, phpunit caches)

## Invariant audit (clean)
Surveyed `src/` for the standard 27-invariant L13 fingerprint — all negative:
- No `DispatchesJobs` trait, no `dispatchNow` (would need `Bus::dispatchSync`)
- No `getDates()` override, no `getDoctrineDriver`, no `getDefaultQueryGrammar`
- No `Illuminate\Database\ConnectionInterface` stubs (no 4th-param `$fetchUsing` fix needed)
- No `Grammar`/`Connection`/`Builder` extensions (no `withTablePrefix`, `compileTableExists`, `compileCreate` signature fixes)
- No CorsService/Mandrill/SparkPost references
- No `array_get`/`camel_case`/`array_except` direct calls in src/ (still polyfilled via `laravel/helpers ^1.8` for runtime BC inherited from df-core)

The package source is intentionally minimal: 7 files, abstract `Services\PubSub`, abstract `Jobs\BaseSubscriber`, two `BaseRestResource` subclasses (`Pub`, `Sub`), one `Components\SwaggerDefinitions` static helper, one `Contracts\MessageQueueInterface`. All inherit from df-core/df-database public-stable bases.

## Test plan
- [x] `composer validate --strict` passes
- [x] Stage 1 isolated install resolves with path-repo aliases for df-core/df-system/df-user/df-database (all on shift/laravel-13)
- [x] `php -l` clean on all 7 source files
- [x] Stage 1 class-load smoke: 7/7 namespaced classes + 3/3 helper polyfills (`array_get`, `camel_case`, `array_except`) under L13.7.0
- [x] Stage 2 host-app install on `shift-173254` with standard sibling strip-list (`df-mongo-logs`, `df-git`, `df-oauth`, `df-mcp-server`) succeeds
- [x] Stage 2 class-load smoke: 7/7 + 3/3 under L13.7.0
- [ ] phpunit (no test directory in package — deferred until host-app suite is L13-green)
- [ ] Live pub/sub backend smoke via df-amqp / df-mqtt sibling packages once those are upgraded

## Wave 3 context
Part of the Laravel 11 -> 13 upgrade campaign. Same composer-only fingerprint as Wave 1 df-system, df-user, df-database — confirms abstract-base packages without LaravelServiceProvider/NoDbModel/TestCase/helpers.php overrides require no source patches.